### PR TITLE
consistenly use tabs instead of mixed tabs and spaces

### DIFF
--- a/SHOUT.sh
+++ b/SHOUT.sh
@@ -1,6 +1,6 @@
 # SHOUT.sh
 # From an original implementation by  @jthistle on github
-# 
+#
 # Alternative iplementation as amended in:
 # https://twitter.com/saruspete/status/1149281131612770304
 # and related thread.
@@ -10,40 +10,40 @@
 # eval "$(echo " foo_orig()";
 # declare -f foo | tail -n +2)"
 # foo() {
-#    # do some new stuff ...
-#    # run original function
-#    foo_orig
+# 	# do some new stuff ...
+# 	# run original function
+# 	foo_orig
 # }
 #
 # Using it makes fell somewhat unclean, though.
 #
 if [[ x$ALF_CMNFH == x ]]; then
-    # check pre-existing handler
-    if [[ x$(typeset -f command_not_found_handle ) != x ]]; then
-	eval "$(echo " command_not_found_handle_orig()"; 
-	declare -f command_not_found_handle | tail -n +2)"
-    fi
-fi
-	
-function command_not_found_handle {
-    # -u makes upppercase
-    typeset -u allcaps="$1"
-    # -i is integer
-    typeset -i ret=127
-    if [[ "$1" == "$allcaps" ]]; then
-	#-l makes lowercase
-	typeset -l cmd="$1";
-	shift
-	sudo "$cmd" "$@"
-	ret=$?
-    else
-	if [[ x$(typeset -f command_not_found_handle_orig) != x ]]; then
-	    command_not_found_handle_orig "$@"
-	else
-	    echo "$1: command not found" 1>&2
+	# check pre-existing handler
+	if [[ x$(typeset -f command_not_found_handle ) != x ]]; then
+		eval "$(echo " command_not_found_handle_orig()";
+		declare -f command_not_found_handle | tail -n +2)"
 	fi
-    fi
-    return $ret
+fi
+
+function command_not_found_handle {
+	# -u makes upppercase
+	typeset -u allcaps="$1"
+	# -i is integer
+	typeset -i ret=127
+	if [[ "$1" == "$allcaps" ]]; then
+		#-l makes lowercase
+		typeset -l cmd="$1";
+		shift
+		sudo "$cmd" "$@"
+		ret=$?
+	else
+		if [[ x$(typeset -f command_not_found_handle_orig) != x ]]; then
+			command_not_found_handle_orig "$@"
+		else
+			echo "$1: command not found" 1>&2
+		fi
+	fi
+	return $ret
 }
 # avoid loops
 export ALF_CMNFH=1


### PR DESCRIPTION
The use of one tab for two indents and four spaces for one indent requires
an 8-column tabstop to view the file correctly. Consistently use tabs so that the file
looks correct regardless of the reader's tabstop. Also remove some extraneous whitespace.